### PR TITLE
ci: change test env to show preview url

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: test
-      url: https://test.feuerwehr-kronshagen.de
+      url: https://test.feuerwehr-kronshagen.de/${{ github.ref_name }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
# Beschreibung

Testen, ob die Test-Umgebung identisch bleiben kann, aber die URL variabel ist. So bleiben alle aktuellen Preview-Deployments im Status "active".

# Wie wurde getestet?

CI-Run

# Checkliste
- [x] Ich habe die Coding Standards eingehalten
- [x] Ich habe Tests hinzugefügt
- [x] Ich habe die Dokumentation aktualisiert
- [x] Ich habe den Code selbst überprüft
- [x] Die Commit-Nachrichten sind nach Conventional Commits formatiert
- [x] Ich habe die Commits gesquasht, um die Historie sauber zu halten
