### PR TITLE
ci: add prod cert generation

### DIFF
--- a/ansible/playbooks/30-certificates.yml
+++ b/ansible/playbooks/30-certificates.yml
@@ -30,6 +30,7 @@
         --agree-tos
         --redirect
         --email homepage@feuerwehr-kronshagen.de
+        -d feuerwehr-kronshagen.de
         -d test.feuerwehr-kronshagen.de
       register: certbot_output
       changed_when: "'Congratulations!' in certbot_output.stdout"


### PR DESCRIPTION
# Beschreibung

<!-- Beschreiben Sie die Änderungen -->

Generierung von Zertifikaten für Domain feuerwehr-kronshagen.de (Produktion) aktiviert.

# Wie wurde getestet?

<!-- Beschreiben Sie, wie Sie Ihre Änderungen getestet haben -->

lokal nicht möglicht - muss in Prod-Run getestet werden.

# Checkliste
- [x] Ich habe die Coding Standards eingehalten
- [x] Ich habe Tests hinzugefügt
- [x] Ich habe die Dokumentation aktualisiert
- [x] Ich habe den Code selbst überprüft
- [x] Die Commit-Nachrichten sind nach Conventional Commits formatiert
- [x] Ich habe die Commits gesquasht, um die Historie sauber zu halten
