### PR TITLE
docs: change codeowners to devs

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,13 +1,1 @@
-content             @Feuerwehr-Kronshagen/vorstand
-LICENSE             @Feuerwehr-Kronshagen/vorstand
-
-hugo.toml           @Feuerwehr-Kronshagen/dev
-makefile            @Feuerwehr-Kronshagen/dev
-requirements.yml    @Feuerwehr-Kronshagen/dev
-assets              @Feuerwehr-Kronshagen/dev
-i18n                @Feuerwehr-Kronshagen/dev
-layouts             @Feuerwehr-Kronshagen/dev
-static              @Feuerwehr-Kronshagen/dev
-
-.github/workflows   @Feuerwehr-Kronshagen/ops
-.ansible            @Feuerwehr-Kronshagen/ops
+* @Feuerwehr-Kronshagen/dev


### PR DESCRIPTION
# Beschreibung

> Beschreiben Sie die Änderungen

Es hat sich gezeigt, dass die bisherige Aufteilung der Zuständigkeiten zu komplex ist und deshalb die Entwicklung stark verzögert. Die Codeownsers Datei wurde so angepasst, dass das Entwicklungsteam automatisch zum Review hinzugefügt wird. Weitere Gruppen jedoch nicht mehr.

# Wie wurde getestet?

> Beschreiben Sie, wie Sie Ihre Änderungen getestet haben

Im Branch gilt die Datei als valid. https://github.com/Feuerwehr-Kronshagen/homepage/blob/docs-codeowners/CODEOWNERS#L1

# Checkliste

- [x] Ich habe die Dokumentation aktualisiert N/A
- [x] Ich habe den Code selbst überprüft N/A
- [x] Die Commit-Nachrichten sind nach Conventional Commits formatiert
- [x] Ich habe die Commits gesquasht, um die Historie sauber zu halten
